### PR TITLE
Add basic customization and scanning features

### DIFF
--- a/newFoodTracker/Models/UserProfile.swift
+++ b/newFoodTracker/Models/UserProfile.swift
@@ -30,6 +30,10 @@ class UserProfile: ObservableObject {
         didSet { UserDefaults.standard.set(focusProtein, forKey: "focusProtein") }
     }
 
+    @Published var planLength: Int = UserDefaults.standard.object(forKey: "planLength") as? Int ?? 7 {
+        didSet { UserDefaults.standard.set(planLength, forKey: "planLength") }
+    }
+
     @Published var calorieGoal: Int = 0
     @Published var proteinGoal: Int = 0
     @Published var carbsGoal: Int = 0
@@ -39,6 +43,7 @@ class UserProfile: ObservableObject {
         // Trigger didSet on load
         _ = weight; _ = isMetric; _ = height; _ = heightIsMetric
         _ = age; _ = gender; _ = exerciseLevel; _ = goal; _ = focusProtein
+        _ = planLength
     }
 
     func calculateMacros() {

--- a/newFoodTracker/Services/MealPlanService.swift
+++ b/newFoodTracker/Services/MealPlanService.swift
@@ -31,7 +31,7 @@ class MealPlanService: ObservableObject {
     func regeneratePlan() {
         let recipes = RecipeService.shared.recipes
         let profile = UserProfileService.shared.currentProfile
-        weeklyPlan = MealPlanner.generateWeeklyPlan(from: recipes, using: profile)
+        weeklyPlan = MealPlanner.generatePlan(days: profile.planLength, from: recipes, using: profile)
     }
 
     private func savePlan() {

--- a/newFoodTracker/Services/MealPlanner.swift
+++ b/newFoodTracker/Services/MealPlanner.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 struct MealPlanner {
-    /// Build a 7-day plan by cycling through the recipe list 5 slots/day.
-    static func generateWeeklyPlan(from recipes: [Recipe], using profile: UserProfile) -> [MealPlanDay] {
-        guard recipes.count >= 5 else { return [] }
+    /// Build a plan by cycling through the recipe list `days` times (5 slots/day).
+    static func generatePlan(days: Int, from recipes: [Recipe], using profile: UserProfile) -> [MealPlanDay] {
+        guard recipes.count >= 5, days > 0 else { return [] }
         var sorted = recipes
         if profile.focusProtein {
             sorted.sort { ($0.protein ?? 0) > ($1.protein ?? 0) }
@@ -11,7 +11,7 @@ struct MealPlanner {
             sorted.shuffle()
         }
         var plan: [MealPlanDay] = []
-        for day in 0..<7 {
+        for day in 0..<days {
             let daily = (0..<5).map { offset in
                 sorted[(day * 5 + offset) % sorted.count]
             }
@@ -25,5 +25,9 @@ struct MealPlanner {
             plan.append(pd)
         }
         return plan
+    }
+
+    static func generateWeeklyPlan(from recipes: [Recipe], using profile: UserProfile) -> [MealPlanDay] {
+        generatePlan(days: 7, from: recipes, using: profile)
     }
 }

--- a/newFoodTracker/Utilities/CacheService.swift
+++ b/newFoodTracker/Utilities/CacheService.swift
@@ -1,0 +1,37 @@
+import Foundation
+import CryptoKit
+
+extension String {
+    var sha256: String {
+        let data = Data(self.utf8)
+        let hash = SHA256.hash(data: data)
+        return hash.compactMap { String(format: "%02x", $0) }.joined()
+    }
+}
+
+extension Data {
+    var sha256: String {
+        let hash = SHA256.hash(data: self)
+        return hash.compactMap { String(format: "%02x", $0) }.joined()
+    }
+}
+
+final class CacheService {
+    static let shared = CacheService()
+    private let cacheDir: URL
+    private init() {
+        let dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        cacheDir = dir.appendingPathComponent("openai_cache")
+        try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+    }
+
+    func cachedResponse(forKey key: String) -> Data? {
+        let url = cacheDir.appendingPathComponent(key)
+        return try? Data(contentsOf: url)
+    }
+
+    func storeResponse(_ data: Data, forKey key: String) {
+        let url = cacheDir.appendingPathComponent(key)
+        try? data.write(to: url)
+    }
+}

--- a/newFoodTracker/Views/AddRecipeView.swift
+++ b/newFoodTracker/Views/AddRecipeView.swift
@@ -8,6 +8,7 @@ struct AddRecipeView: View {
     @State private var instructions = ""
     @State private var showingImagePicker = false
     @State private var selectedImage: UIImage?
+    @State private var showingScanner = false
     @State private var calories: String? = nil
     @State private var protein: String? = nil
     @State private var carbs: String? = nil
@@ -96,6 +97,10 @@ struct AddRecipeView: View {
                                 // Optionally handle denial (e.g., show an alert)
                             }
                         }
+                    }
+                    .buttonStyle(PrimaryButtonStyle())
+                    Button("Scan Barcode") {
+                        showingScanner = true
                     }
                     .buttonStyle(PrimaryButtonStyle())
                 }
@@ -191,6 +196,16 @@ struct AddRecipeView: View {
                 }
             }) {
                 ImagePicker(image: $selectedImage)
+            }
+            .sheet(isPresented: $showingScanner) {
+                if #available(iOS 16.0, *) {
+                    BarcodeScannerView { code in
+                        ingredientEntries.append(IngredientEntry(name: code))
+                    }
+                } else {
+                    Text("Barcode scanning requires iOS 16")
+                        .padding()
+                }
             }
         }
     }

--- a/newFoodTracker/Views/Components/BarcodeScannerView.swift
+++ b/newFoodTracker/Views/Components/BarcodeScannerView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import VisionKit
+
+@available(iOS 16.0, *)
+struct BarcodeScannerView: UIViewControllerRepresentable {
+    var onScan: (String) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIViewController(context: Context) -> DataScannerViewController {
+        let vc = DataScannerViewController(recognizedDataTypes: [.barcode()], isGuidanceEnabled: true)
+        vc.delegate = context.coordinator
+        return vc
+    }
+
+    func updateUIViewController(_ uiViewController: DataScannerViewController, context: Context) {}
+
+    class Coordinator: NSObject, DataScannerViewControllerDelegate {
+        let parent: BarcodeScannerView
+        init(_ parent: BarcodeScannerView) { self.parent = parent }
+        func dataScanner(_ dataScanner: DataScannerViewController, didTapOn item: RecognizedItem) {
+            if case .barcode(let barcode) = item {
+                parent.onScan(barcode.payloadStringValue ?? "")
+                parent.dismiss()
+            }
+        }
+    }
+}
+
+#if !available(iOS 16.0, *)
+struct BarcodeScannerView: View {
+    var onScan: (String) -> Void
+    var body: some View {
+        Text("Scanning not supported on this iOS version")
+            .padding()
+    }
+}
+#endif
+

--- a/newFoodTracker/Views/RecipesView.swift
+++ b/newFoodTracker/Views/RecipesView.swift
@@ -4,11 +4,17 @@ struct RecipesView: View {
     @EnvironmentObject var recipeService: RecipeService
     @State private var showingEditRecipe = false
     @State private var recipeToEdit: Recipe? = nil
+    @State private var searchText: String = ""
+
+    private var filteredRecipes: [Recipe] {
+        if searchText.isEmpty { return recipeService.recipes }
+        return recipeService.recipes.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+    }
 
     var body: some View {
         NavigationView {
             List {
-                ForEach(recipeService.recipes) { recipe in
+                ForEach(filteredRecipes) { recipe in
                     HStack {
                         Text(recipe.name)
                             .font(.headline)
@@ -31,6 +37,7 @@ struct RecipesView: View {
             .listStyle(PlainListStyle())
             .scrollContentBackground(.hidden)
             .background(Color.primaryBackground)
+            .searchable(text: $searchText, prompt: "Search Recipes")
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {

--- a/newFoodTracker/Views/SettingsView.swift
+++ b/newFoodTracker/Views/SettingsView.swift
@@ -93,7 +93,15 @@ struct SettingsView: View {
                     }
                     .pickerStyle(MenuPickerStyle())
 
-                    Toggle("Extra Protein Focus", isOn: $userProfile.focusProtein)
+                Toggle("Extra Protein Focus", isOn: $userProfile.focusProtein)
+                }
+                .listRowBackground(Color.cardBackground)
+                .cornerRadius(8)
+
+                Section(header: Text("Meal Plan").foregroundColor(Color.primary)) {
+                    Stepper(value: $userProfile.planLength, in: 3...14) {
+                        Text("Plan Length: \(userProfile.planLength) days")
+                    }
                 }
                 .listRowBackground(Color.cardBackground)
                 .cornerRadius(8)


### PR DESCRIPTION
## Summary
- add `planLength` setting in `UserProfile` and regenerate plan with that value
- support variable plan generation in `MealPlanner`
- add search bar to recipe list
- add basic barcode scanner view and integrate in `AddRecipeView`
- include placeholder `CacheService` for future offline work

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6854577d55ec83338639476ae9b165eb